### PR TITLE
Theming - Take 2

### DIFF
--- a/Sources/MyStyles/ColorToken.swift
+++ b/Sources/MyStyles/ColorToken.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+// MARK: - Functional Color Tokens
+
+public enum ColorToken {
+    // Surfaces
+    case surface, surfaceInverse
+    case background, backgroundInverse
+    
+    // Content
+    case content, contentInverse
+    case contentSubtle, contentSubtleInverse
+    case contentDisabled, contentDisabledInverse
+    case contentSuccess, contentSuccessInverse
+    case contentCritical, contentCriticalInverse
+    case border, borderInverse
+    case divider, dividerInverse
+    
+    // Actions
+    case actionPrimary, actionPrimaryInverse
+    case actionPrimaryBold, actionPrimaryBoldInverse
+    case actionSecondary, actionSecondaryInverse
+    case actionDisabled, actionDisabledInverse
+    case actionIcon
+    
+    // Ratings
+    case rating9, rating9Inverse
+    case rating8, rating8Inverse
+    case rating7, rating7Inverse
+    case rating6, rating6Inverse
+    case rating5, rating5Inverse
+}

--- a/Sources/MyStyles/MyColors.swift
+++ b/Sources/MyStyles/MyColors.swift
@@ -2,46 +2,10 @@ import SwiftUI
 
 public typealias MyColor = Color
 
-// MARK: - Functional Color Tokens
-
-extension MyColor {
-
-    // MARK: - Surfaces
-
-    public static let surface: MyColor = .neutral1
-    public static let background: MyColor = .neutral2
-
-    // MARK: - Content
-
-    public static let content: MyColor = .neutral9
-    public static let contentSubtle: MyColor = .neutral6
-    public static let contentDisabled: MyColor = .neutral4
-    public static let contentSuccess: MyColor = .green2
-    public static let contentCritical: MyColor = .red2
-    public static let border: MyColor = .neutral3
-    public static let divider: MyColor = .neutral3
-
-    // MARK: - Actions
-
-    public static let actionPrimary: MyColor = .red2
-    public static let actionPrimaryBold: MyColor = .neutral9
-    public static let actionSecondary: MyColor = .neutral2
-    public static let actionDisabled: MyColor = .neutral2
-    public static let actionIcon: MyColor = .neutral2
-
-    // MARK: - Rating Scale
-
-    public static let rating9: MyColor = .yellow2
-    public static let rating8: MyColor = .orange2
-    public static let rating7: MyColor = .red2
-    public static let rating6: MyColor = .red3
-    public static let rating5: MyColor = .neutral9
-}
-
 // MARK: - Primitive Color Tokens
 
-private extension MyColor {
-
+internal extension MyColor {
+    
     // MARK: - Primary Primitives
 
     static let red1 = Color("red1", bundle: .module)

--- a/Sources/MyStyles/MyStyles.swift
+++ b/Sources/MyStyles/MyStyles.swift
@@ -1,6 +1,9 @@
 import Foundation
-import UIKit
 import CoreGraphics
+
+#if canImport(UIKit)
+import UIKit
+#endif
 
 public struct MyStyles {
 

--- a/Sources/MyStyles/Theming/Modifiers/Shape.swift
+++ b/Sources/MyStyles/Theming/Modifiers/Shape.swift
@@ -1,0 +1,32 @@
+import Foundation
+import SwiftUI
+
+extension Shape {
+    public func stroke(_ colorToken: ColorToken, lineWidth: CGFloat = 1, themeType: ThemeType = .default) -> some View {
+        let color = themeType.theme.color(for: colorToken)
+        
+        return self.stroke(color, lineWidth: lineWidth)
+    }
+    
+    public func stroke(_ colorToken: ColorToken, lineWidth: CGFloat = 1, themeEngine: ThemeEngine) -> some View {
+        return self.stroke(colorToken,
+                           lineWidth: lineWidth,
+                           themeType: themeEngine.currentThemeType)
+    }
+}
+
+struct ShapeStroke_Previews: PreviewProvider {
+     static var previews: some View {
+         Group {
+             Circle()
+                 .stroke(.content, lineWidth: 3)
+                 .previewLayout(.fixed(width: 100, height: 100))
+                 .padding()
+             
+             Circle()
+                 .stroke(.content, lineWidth: 3, themeType: .silly)
+                 .previewLayout(.fixed(width: 100, height: 100))
+                 .padding()
+         }
+     }
+}

--- a/Sources/MyStyles/Theming/Modifiers/ThemedBackgroundColorModifier.swift
+++ b/Sources/MyStyles/Theming/Modifiers/ThemedBackgroundColorModifier.swift
@@ -1,0 +1,45 @@
+import Foundation
+import SwiftUI
+
+internal struct ThemedBackgroundColorModifier: ViewModifier {
+    @Environment(\.themeEngine) internal var themeEngine
+    
+    var colorToken: ColorToken
+    
+    func body(content: Content) -> some View {
+        content
+            .background(themeEngine.currentTheme.color(for: colorToken))
+    }
+    
+    init(_ colorToken: ColorToken) {
+        self.colorToken = colorToken
+    }
+}
+
+extension View {
+    public func background(_ colorToken: ColorToken) -> some View {
+        modifier(
+            ThemedBackgroundColorModifier(colorToken)
+        )
+    }
+}
+
+struct ThemedBackgroundColorModifier_Previews: PreviewProvider {
+     static var previews: some View {
+         Group {
+             Text("Hi")
+                 .padding()
+                 .previewLayout(.fixed(width: 100, height: 100))
+                 .foregroundColor(.white)
+                 .background(.content)
+                 
+             
+             Text("Hi")
+                 .padding()
+                 .previewLayout(.fixed(width: 100, height: 100))
+                 .background(.content)
+                 .foregroundColor(.white)
+                 .themeType(.silly)
+         }
+     }
+ }

--- a/Sources/MyStyles/Theming/Modifiers/ThemedForegroundColorModifier.swift
+++ b/Sources/MyStyles/Theming/Modifiers/ThemedForegroundColorModifier.swift
@@ -1,0 +1,40 @@
+import Foundation
+import SwiftUI
+
+internal struct ThemedForegroundColorModifier: ViewModifier {
+    @Environment(\.themeEngine) internal var themeEngine
+    
+    var colorToken: ColorToken
+    
+    func body(content: Content) -> some View {
+        content
+            .foregroundColor(themeEngine.currentTheme.color(for: colorToken))
+    }
+    
+    init(_ colorToken: ColorToken) {
+        self.colorToken = colorToken
+    }
+}
+
+extension View {
+    public func foregroundColor(_ colorToken: ColorToken) -> some View {
+        modifier(
+            ThemedForegroundColorModifier(colorToken)
+        )
+    }
+}
+
+struct ThemedForegroundColorModifier_Previews: PreviewProvider {
+     static var previews: some View {
+         Group {
+             Text("Hi")
+                 .previewLayout(.fixed(width: 100, height: 100))
+                 .foregroundColor(.content)
+             
+             Text("Hi")
+                 .previewLayout(.fixed(width: 100, height: 100))
+                 .foregroundColor(.content)
+                 .themeType(.silly)
+         }
+     }
+ }

--- a/Sources/MyStyles/Theming/Modifiers/View.swift
+++ b/Sources/MyStyles/Theming/Modifiers/View.swift
@@ -1,0 +1,14 @@
+import Foundation
+import SwiftUI
+
+extension View {
+    public func themeType(_ themeType: ThemeType) -> some View {
+        return self
+            .environment(\.themeEngine, ThemeEngine(themeType: themeType))
+    }
+    
+    public func themeEngine(_ themeEngine: ThemeEngine) -> some View {
+        return self
+            .environment(\.themeEngine, themeEngine)
+    }
+}

--- a/Sources/MyStyles/Theming/ThemeEngine.swift
+++ b/Sources/MyStyles/Theming/ThemeEngine.swift
@@ -1,0 +1,33 @@
+import Foundation
+import SwiftUI
+
+public class ThemeEngine: ObservableObject {
+    @Published private(set) public var currentThemeType: ThemeType
+    
+    public var currentTheme: Theming {
+        currentThemeType.theme
+    }
+    
+    public init(themeType: ThemeType = .default) {
+        self.currentThemeType = themeType
+    }
+    
+    public func set(_ themeType: ThemeType) {
+        self.currentThemeType = themeType
+    }
+    
+    func color(for colorToken: ColorToken) -> MyColor {
+        currentThemeType.theme.color(for: colorToken)
+    }
+}
+
+private struct ThemeEngineKey: EnvironmentKey {
+    static let defaultValue: ThemeEngine = ThemeEngine()
+}
+
+extension EnvironmentValues {
+    public var themeEngine: ThemeEngine {
+        get { self[ThemeEngineKey.self] }
+        set { self[ThemeEngineKey.self] = newValue }
+    }
+}

--- a/Sources/MyStyles/Theming/ThemeType.swift
+++ b/Sources/MyStyles/Theming/ThemeType.swift
@@ -1,0 +1,30 @@
+import Foundation
+import SwiftUI
+
+public enum ThemeType: String {
+    case legacy, metalabsv1, silly
+    
+    public static var `default`: ThemeType = .legacy
+    
+    public var description: String {
+        switch self {
+        case .legacy:       return "Our Legacy theme"
+        case .metalabsv1:   return "The MetaLabs theme"
+        case .silly:        return "A Silly theme"
+        }
+    }
+    
+    internal var theme: Theming {
+        switch self {
+        case .legacy:       return LegacyTheme()
+        case .metalabsv1:   return MetaLabsV1Theme()
+        case .silly:        return SillyTheme()
+        }
+    }
+}
+
+extension ThemeType: CaseIterable { }
+
+extension ThemeType: Identifiable {
+    public var id: String { rawValue }
+}

--- a/Sources/MyStyles/Theming/ThemeType.swift
+++ b/Sources/MyStyles/Theming/ThemeType.swift
@@ -6,6 +6,14 @@ public enum ThemeType: String {
     
     public static var `default`: ThemeType = .legacy
     
+    public var title: String {
+        switch self {
+        case .legacy:       return "Legacy"
+        case .metalabsv1:   return "MetaLabs"
+        case .silly:        return "Silly"
+        }
+    }
+    
     public var description: String {
         switch self {
         case .legacy:       return "Our Legacy theme"

--- a/Sources/MyStyles/Theming/Themes/LegacyTheme.swift
+++ b/Sources/MyStyles/Theming/Themes/LegacyTheme.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+internal struct LegacyTheme: Theming {
+    // Surfaces
+    var surface: MyColor { .neutral1 }
+    var surfaceInverse: MyColor { .neutral7 }
+    var background: MyColor { .neutral2 }
+    var backgroundInverse: MyColor { .neutral9 }
+    
+    // Content
+    var content: MyColor { .neutral9 }
+    var contentInverse: MyColor { .neutral1 }
+    var contentSubtle: MyColor { .neutral6 }
+    var contentSubtleInverse: MyColor { .neutral4 }
+    var contentDisabled: MyColor { .neutral4 }
+    var contentDisabledInverse: MyColor { .neutral6 }
+    var contentSuccess: MyColor { .green2 }
+    var contentSuccessInverse: MyColor { contentSuccess }
+    var contentCritical: MyColor { .red2 }
+    var contentCriticalInverse: MyColor { contentCritical }
+    var border: MyColor { .neutral3 }
+    var borderInverse: MyColor { .neutral8 }
+    var divider: MyColor { .neutral3 }
+    var dividerInverse: MyColor { .neutral7 }
+    
+    // Actions
+    var actionPrimary: MyColor { .red2 }
+    var actionPrimaryInverse: MyColor { actionPrimary }
+    var actionPrimaryBold: MyColor { .neutral9 }
+    var actionPrimaryBoldInverse: MyColor { .neutral1 }
+    var actionSecondary: MyColor { .neutral2 }
+    var actionSecondaryInverse: MyColor { .neutral7 }
+    var actionDisabled: MyColor { .neutral2 }
+    var actionDisabledInverse: MyColor { .neutral7 }
+    var actionIcon: MyColor { .neutral5 }
+    
+    // Rating scale
+    var rating9: MyColor { .yellow2 }
+    var rating9Inverse: MyColor { rating9 }
+    var rating8: MyColor { .orange2 }
+    var rating8Inverse: MyColor { rating8 }
+    var rating7: MyColor { .red2 }
+    var rating7Inverse: MyColor { rating7 }
+    var rating6: MyColor { .red3 }
+    var rating6Inverse: MyColor { rating6 }
+    var rating5: MyColor { .neutral9 }
+    var rating5Inverse: MyColor { rating5 }
+}

--- a/Sources/MyStyles/Theming/Themes/MetaLabsV1Theme.swift
+++ b/Sources/MyStyles/Theming/Themes/MetaLabsV1Theme.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+internal struct MetaLabsV1Theme: Theming {
+    // Surfaces
+    var surface: MyColor { .neutral1 }
+    var surfaceInverse: MyColor { .neutral7 }
+    var background: MyColor { .neutral2 }
+    var backgroundInverse: MyColor { .neutral9 }
+    
+    // Content
+    var content: MyColor { .neutral9 }
+    var contentInverse: MyColor { .neutral1 }
+    var contentSubtle: MyColor { .neutral6 }
+    var contentSubtleInverse: MyColor { .neutral4 }
+    var contentDisabled: MyColor { .neutral4 }
+    var contentDisabledInverse: MyColor { .neutral6 }
+    var contentSuccess: MyColor { .green2 }
+    var contentSuccessInverse: MyColor { contentSuccess }
+    var contentCritical: MyColor { .red2 }
+    var contentCriticalInverse: MyColor { contentCritical }
+    var border: MyColor { .neutral3 }
+    var borderInverse: MyColor { .neutral8 }
+    var divider: MyColor { .neutral3 }
+    var dividerInverse: MyColor { .neutral7 }
+    
+    // Actions
+    var actionPrimary: MyColor { .red2 }
+    var actionPrimaryInverse: MyColor { actionPrimary }
+    var actionPrimaryBold: MyColor { .neutral9 }
+    var actionPrimaryBoldInverse: MyColor { .neutral1 }
+    var actionSecondary: MyColor { .neutral2 }
+    var actionSecondaryInverse: MyColor { .neutral7 }
+    var actionDisabled: MyColor { .neutral2 }
+    var actionDisabledInverse: MyColor { .neutral7 }
+    var actionIcon: MyColor { .neutral5 }
+    
+    // Rating scale
+    var rating9: MyColor { .yellow2 }
+    var rating9Inverse: MyColor { rating9 }
+    var rating8: MyColor { .orange2 }
+    var rating8Inverse: MyColor { rating8 }
+    var rating7: MyColor { .red2 }
+    var rating7Inverse: MyColor { rating7 }
+    var rating6: MyColor { .red3 }
+    var rating6Inverse: MyColor { rating6 }
+    var rating5: MyColor { .neutral9 }
+    var rating5Inverse: MyColor { rating5 }
+}

--- a/Sources/MyStyles/Theming/Themes/SillyTheme.swift
+++ b/Sources/MyStyles/Theming/Themes/SillyTheme.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+internal struct SillyTheme: Theming {
+    // Surfaces
+    var surface: MyColor { .white }
+    var surfaceInverse: MyColor { .gray }
+    var background: MyColor { .white }
+    var backgroundInverse: MyColor { .blue }
+    
+    // Content
+    var content: MyColor { .blue }
+    var contentInverse: MyColor { .pink }
+    var contentSubtle: MyColor { .purple }
+    var contentSubtleInverse: MyColor { .primary }
+    var contentDisabled: MyColor { .gray }
+    var contentDisabledInverse: MyColor { .blue }
+    var contentSuccess: MyColor { .blue }
+    var contentSuccessInverse: MyColor { .red }
+    var contentCritical: MyColor { .green }
+    var contentCriticalInverse: MyColor { .yellow }
+    var border: MyColor { .yellow }
+    var borderInverse: MyColor { .red }
+    var divider: MyColor { .pink }
+    var dividerInverse: MyColor { surface }
+    
+    // Actions
+    var actionPrimary: MyColor { .black }
+    var actionPrimaryInverse: MyColor { .green }
+    var actionPrimaryBold: MyColor { .black }
+    var actionPrimaryBoldInverse: MyColor { .pink }
+    var actionSecondary: MyColor { .blue }
+    var actionSecondaryInverse: MyColor { .orange }
+    var actionDisabled: MyColor { .orange }
+    var actionDisabledInverse: MyColor { .red }
+    var actionIcon: MyColor { .red }
+    
+    // Rating scale
+    var rating9: MyColor { .yellow }
+    var rating9Inverse: MyColor { rating9 }
+    var rating8: MyColor { .orange }
+    var rating8Inverse: MyColor { rating8 }
+    var rating7: MyColor { .red }
+    var rating7Inverse: MyColor { rating7 }
+    var rating6: MyColor { .red }
+    var rating6Inverse: MyColor { rating6 }
+    var rating5: MyColor { .gray }
+    var rating5Inverse: MyColor { rating5 }
+}

--- a/Sources/MyStyles/Theming/Theming.swift
+++ b/Sources/MyStyles/Theming/Theming.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+public protocol Theming {
+    // Surfaces
+    var surface: MyColor { get }
+    var surfaceInverse: MyColor { get }
+    var background: MyColor { get }
+    var backgroundInverse: MyColor { get }
+    
+    // Content
+    var content: MyColor { get }
+    var contentInverse: MyColor { get }
+    var contentSubtle: MyColor { get }
+    var contentSubtleInverse: MyColor { get }
+    var contentDisabled: MyColor { get }
+    var contentDisabledInverse: MyColor { get }
+    var contentSuccess: MyColor { get }
+    var contentSuccessInverse: MyColor { get }
+    var contentCritical: MyColor { get }
+    var contentCriticalInverse: MyColor { get }
+    var border: MyColor { get }
+    var borderInverse: MyColor { get }
+    var divider: MyColor { get }
+    var dividerInverse: MyColor { get }
+    
+    // Actions
+    var actionPrimary: MyColor { get }
+    var actionPrimaryInverse: MyColor { get }
+    var actionPrimaryBold: MyColor { get }
+    var actionPrimaryBoldInverse: MyColor { get }
+    var actionSecondary: MyColor { get }
+    var actionSecondaryInverse: MyColor { get }
+    var actionDisabled: MyColor { get }
+    var actionDisabledInverse: MyColor { get }
+    var actionIcon: MyColor { get }
+    
+    // Ratings
+    var rating9: MyColor { get }
+    var rating9Inverse: MyColor { get }
+    var rating8: MyColor { get }
+    var rating8Inverse: MyColor { get }
+    var rating7: MyColor { get }
+    var rating7Inverse: MyColor { get }
+    var rating6: MyColor { get }
+    var rating6Inverse: MyColor { get }
+    var rating5: MyColor { get }
+    var rating5Inverse: MyColor { get }
+    
+    // General
+    func color(for colorToken: ColorToken) -> MyColor
+}
+
+extension Theming {
+    func color(for colorToken: ColorToken) -> MyColor {
+        switch colorToken {
+        case .surface:                  return surface
+        case .surfaceInverse:           return surfaceInverse
+        case .background:               return background
+        case .backgroundInverse:        return backgroundInverse
+        case .content:                  return content
+        case .contentInverse:           return contentInverse
+        case .contentSubtle:            return contentSubtle
+        case .contentSubtleInverse:     return contentSubtleInverse
+        case .contentDisabled:          return contentDisabled
+        case .contentDisabledInverse:   return contentDisabledInverse
+        case .contentSuccess:           return contentSuccess
+        case .contentSuccessInverse:    return contentSuccessInverse
+        case .contentCritical:          return contentCritical
+        case .contentCriticalInverse:   return contentCriticalInverse
+        case .border:                   return border
+        case .borderInverse:            return borderInverse
+        case .divider:                  return divider
+        case .dividerInverse:           return dividerInverse
+        case .actionPrimary:            return actionPrimary
+        case .actionPrimaryInverse:     return actionPrimaryInverse
+        case .actionPrimaryBold:        return actionPrimaryBold
+        case .actionPrimaryBoldInverse: return actionPrimaryBoldInverse
+        case .actionSecondary:          return actionSecondary
+        case .actionSecondaryInverse:   return actionSecondaryInverse
+        case .actionDisabled:           return actionDisabled
+        case .actionDisabledInverse:    return actionDisabledInverse
+        case .actionIcon:               return actionIcon
+        case .rating9:                  return rating9
+        case .rating9Inverse:           return rating9Inverse
+        case .rating8:                  return rating8
+        case .rating8Inverse:           return rating8Inverse
+        case .rating7:                  return rating7
+        case .rating7Inverse:           return rating7Inverse
+        case .rating6:                  return rating6
+        case .rating6Inverse:           return rating6Inverse
+        case .rating5:                  return rating5
+        case .rating5Inverse:           return rating5Inverse
+        }
+    }
+}


### PR DESCRIPTION
Hopefully this is a better attempt at theming for the component library. 

- Replaced the existing colors with color tokens (which are then converted to colors later on). 
- Added view modifiers to aid in converting color tokens to colors (by theme). 
- Added extensions on `View` to apply the view modifiers above. 
- Added an extension on `Shape` to allow for themed `stroke` calls. 
- Added environment keys so that the theme engine can be used throughout an app. 
- Added three sample themes. 

Note about the view modifiers:
I've created extensions on `View` that allow for `foregroundColor(_ colorToken: ColorToken)`, and `background(_ colorToken: ColorToken)`, these will allow developers to pass in a color token and the view modifier will grab the theme from the environment and apply the proper color. 

One note about the `Shape` extension. I couldn't get a `ViewModifier` to work for just a `Shape`. I think it's my inexperience with SwiftUI (or generics) and my poor Google-foo. But the extension I created will (optionally) need to have the current `themeEngine` passed into it (or else it'll use the default theme) to produce the correct color. If you know how to fix this, I'm all ears. 