### PR TITLE
Themeing Ideas

### DIFF
--- a/Sources/MyStyles/ColorTokens.swift
+++ b/Sources/MyStyles/ColorTokens.swift
@@ -1,0 +1,13 @@
+public extension MyColor {
+
+    private static var colorProvider: ColorProvider.Type { ThemingEngine.colorProvider }
+
+    static var token1: MyColor {
+        return colorProvider.actionDisabled
+    }
+
+    static var token2: MyColor {
+        return colorProvider.actionIcon
+    }
+}
+

--- a/Sources/MyStyles/ColorTokens.swift
+++ b/Sources/MyStyles/ColorTokens.swift
@@ -1,3 +1,4 @@
+// These represent the functional tokens
 public extension MyColor {
 
     private static var colorProvider: ColorProvider.Type { ThemingEngine.colorProvider }

--- a/Sources/MyStyles/MyColors.swift
+++ b/Sources/MyStyles/MyColors.swift
@@ -2,40 +2,96 @@ import SwiftUI
 
 public typealias MyColor = Color
 
+protocol ColorProvider {
+    static var surface: MyColor { get }
+    static var background: MyColor { get }
+    static var content: MyColor  { get }
+    static var contentSubtle: MyColor { get }
+    static var contentDisabled: MyColor { get }
+    static var contentSuccess: MyColor { get }
+    static var contentCritical: MyColor { get }
+    static var border: MyColor { get }
+    static var divider: MyColor { get }
+    static var actionPrimary: MyColor  { get }
+    static var actionPrimaryBold: MyColor { get }
+    static var actionSecondary: MyColor { get }
+    static var actionDisabled: MyColor  { get }
+    static var actionIcon: MyColor { get }
+    static var rating9: MyColor  { get }
+    static var rating8: MyColor { get }
+    static var rating7: MyColor { get }
+    static var rating6: MyColor { get }
+    static var rating5: MyColor { get }
+}
+
 // MARK: - Functional Color Tokens
 
-extension MyColor {
+enum StandardColors: ColorProvider {
 
     // MARK: - Surfaces
 
-    public static let surface: MyColor = .neutral1
-    public static let background: MyColor = .neutral2
+    static let surface: MyColor = .neutral1
+    static let background: MyColor = .neutral2
 
     // MARK: - Content
 
-    public static let content: MyColor = .neutral9
-    public static let contentSubtle: MyColor = .neutral6
-    public static let contentDisabled: MyColor = .neutral4
-    public static let contentSuccess: MyColor = .green2
-    public static let contentCritical: MyColor = .red2
-    public static let border: MyColor = .neutral3
-    public static let divider: MyColor = .neutral3
+    static let content: MyColor = .neutral9
+    static let contentSubtle: MyColor = .neutral6
+    static let contentDisabled: MyColor = .neutral4
+    static let contentSuccess: MyColor = .green2
+    static let contentCritical: MyColor = .red2
+    static let border: MyColor = .neutral3
+    static let divider: MyColor = .neutral3
 
     // MARK: - Actions
 
-    public static let actionPrimary: MyColor = .red2
-    public static let actionPrimaryBold: MyColor = .neutral9
-    public static let actionSecondary: MyColor = .neutral2
-    public static let actionDisabled: MyColor = .neutral2
-    public static let actionIcon: MyColor = .neutral2
+    static let actionPrimary: MyColor = .red2
+    static let actionPrimaryBold: MyColor = .neutral9
+    static let actionSecondary: MyColor = .neutral2
+    static let actionDisabled: MyColor = .neutral2
+    static let actionIcon: MyColor = .neutral2
 
     // MARK: - Rating Scale
 
-    public static let rating9: MyColor = .yellow2
-    public static let rating8: MyColor = .orange2
-    public static let rating7: MyColor = .red2
-    public static let rating6: MyColor = .red3
-    public static let rating5: MyColor = .neutral9
+    static let rating9: MyColor = .yellow2
+    static let rating8: MyColor = .orange2
+    static let rating7: MyColor = .red2
+    static let rating6: MyColor = .red3
+    static let rating5: MyColor = .neutral9
+}
+
+enum SomeOtherColors: ColorProvider {
+
+    // MARK: - Surfaces
+
+    static let surface: MyColor = .blue
+    static let background: MyColor = .red
+
+    // MARK: - Content
+
+    static let content: MyColor = .green
+    static let contentSubtle: MyColor = .gray
+    static let contentDisabled: MyColor = .white
+    static let contentSuccess: MyColor = .black
+    static let contentCritical: MyColor = .orange
+    static let border: MyColor = .purple
+    static let divider: MyColor = .blue
+
+    // MARK: - Actions
+
+    static let actionPrimary: MyColor = .pink
+    static let actionPrimaryBold: MyColor = .red
+    static let actionSecondary: MyColor = .yellow
+    static let actionDisabled: MyColor = .green
+    static let actionIcon: MyColor = .black
+
+    // MARK: - Rating Scale
+
+    static let rating9: MyColor = .clear
+    static let rating8: MyColor = .orange2
+    static let rating7: MyColor = .red2
+    static let rating6: MyColor = .red3
+    static let rating5: MyColor = .neutral9
 }
 
 // MARK: - Primitive Color Tokens

--- a/Sources/MyStyles/MyColors.swift
+++ b/Sources/MyStyles/MyColors.swift
@@ -24,8 +24,7 @@ protocol ColorProvider {
     static var rating5: MyColor { get }
 }
 
-// MARK: - Functional Color Tokens
-
+// MARK: - These map to primitives for one theme
 enum StandardColors: ColorProvider {
 
     // MARK: - Surfaces
@@ -59,6 +58,8 @@ enum StandardColors: ColorProvider {
     static let rating6: MyColor = .red3
     static let rating5: MyColor = .neutral9
 }
+
+//MARK: - These map to primatives for a different theme
 
 enum SomeOtherColors: ColorProvider {
 

--- a/Sources/MyStyles/Resources/Colors.xcassets/neutral2.colorset/Contents.json
+++ b/Sources/MyStyles/Resources/Colors.xcassets/neutral2.colorset/Contents.json
@@ -11,6 +11,24 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.895",
+          "green" : "0.321",
+          "red" : "0.256"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Sources/MyStyles/SwiftUIView.swift
+++ b/Sources/MyStyles/SwiftUIView.swift
@@ -10,8 +10,8 @@ import SwiftUI
 struct Model {
     init() {
         // comment out one or both to either change themes, or test defaulting
-        ThemingEngine.registerTheme(theme: .different)
-//        ThemingEngine.registerTheme(theme: .standard)
+//        ThemingEngine.registerTheme(theme: .different)
+        ThemingEngine.registerTheme(theme: .standard)
     }
 }
 
@@ -27,5 +27,6 @@ struct SwiftUIView: View {
 struct SwiftUIView_Previews: PreviewProvider {
     static var previews: some View {
         SwiftUIView().previewLayout(.fixed(width: 375, height: 77))
+        SwiftUIView().preferredColorScheme(.dark).previewLayout(.fixed(width: 375, height: 77))
     }
 }

--- a/Sources/MyStyles/SwiftUIView.swift
+++ b/Sources/MyStyles/SwiftUIView.swift
@@ -1,0 +1,31 @@
+//
+//  SwiftUIView.swift
+//  
+//
+//  Created by Aidan Malone on 15/10/2021.
+//
+
+import SwiftUI
+
+struct Model {
+    init() {
+        // comment out one or both to either change themes, or test defaulting
+        ThemingEngine.registerTheme(theme: .different)
+//        ThemingEngine.registerTheme(theme: .standard)
+    }
+}
+
+struct SwiftUIView: View {
+    let model = Model()
+
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+            .background(Color.token1)
+    }
+}
+
+struct SwiftUIView_Previews: PreviewProvider {
+    static var previews: some View {
+        SwiftUIView().previewLayout(.fixed(width: 375, height: 77))
+    }
+}

--- a/Sources/MyStyles/Theming.swift
+++ b/Sources/MyStyles/Theming.swift
@@ -1,0 +1,29 @@
+public enum Theme {
+    case standard
+    case different
+
+    static let fallback: Theme = .standard
+}
+
+public class ThemingEngine {
+    private static var theme: Theme = .fallback {
+        didSet {
+            colorProvider = theme.colorProvider
+        }
+    }
+
+    private(set) static var colorProvider: ColorProvider.Type = theme.colorProvider
+
+    static func registerTheme(theme: Theme) {
+        Self.theme = theme
+    }
+}
+
+private extension Theme {
+    var colorProvider: ColorProvider.Type {
+        switch self {
+        case .standard: return StandardColors.self
+        case .different: return SomeOtherColors.self
+        }
+    }
+}


### PR DESCRIPTION
This is a wee poc on an idea to manage the themeing by swapping out the colours implementation underneath the publicly exposed functional tokens. Heres the list:

- Theres an internal protocol named §ColorProvider§, it defines static properties for the functional tokens
- Theres two internal objects conforming to §ColorProvider§, holding static properties for the functional tokens and mapping them to a primitive
- Theres a public extension on the SwiftUI Color type, which exposes the functional tokens outside the library
- Theres a ThemeEngine, which registers a theme and holds a colorProvider property, which is of type ColorProvider.Type
- When we change the theme, it updates the colorProvider property to a different implementation of ColorProvider
- When we request a color token through the public extension on Color, it then calls theme.colorProvider.color

What it hopefully means is:

- Consuming Apps can make a single call to select a theme
- Consuming Apps can change that theme at any time
- Our functional tokens are still of type SwiftUI.Color, so we keep api compatability
- We don’t do any logic on request of a color, logic is only applied on theme change
- We should be able to extend the pattern to other functional tokens beyond the colours if we need to in future